### PR TITLE
add consistency, fix display of times, update readme,  show final results time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![npm version](https://badge.fury.io/js/cypress-parallel.svg)](https://badge.fury.io/js/cypress-parallel)
 # cypress-parallel
 Reduce up to 40% your Cypress suite execution time parallelizing the test run on the same machine.
- 
+
 # Run your Cypress test in parallel (locally)
 
 ## How it works
@@ -18,7 +18,7 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
  npm i cypress-parallel
  ```
 
- or 
+ or
 
 ```
 yarn add cypress-parallel
@@ -60,6 +60,7 @@ npm run cy:parallel
 | --args     | -a    | Your npm Cypress command arguments | string |
 | --threads  | -t    | Number of threads                  | number |
 | --specsDir | -d    | Cypress specs directory.           | string |
+| --write_weights_file   | -wwf    | if a weights file should be crated; default false           | boolean |
 
 # Contributors
 Looking for contributors.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ npm run cy:parallel
 | --threads    | -t    | Number of threads; must be even #  | number | 4                   |
 
 # Contributors
-  Original Author: https://github.com/tnicola
-  Total Test Time: https://github.com/stepn1k
-  Updates and cleanup: https://github.com/sezane
-  Few small tweaks: me @ https://github.com/finalcut
+ *  Original Author: https://github.com/tnicola
+ *  Total Test Time: https://github.com/stepn1k
+ *  Updates and cleanup: https://github.com/sezane
+ *  Few small tweaks: me @ https://github.com/finalcut
 # License
  MIT

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ npm run cy:parallel
 
 ### Scripts options
 
-| Option       | Alias | Description                        | Type   | Default |
-| ------------ | ----- | ---------------------------------- | ------ | ------ |
+| Option       | Alias | Description                        | Type   | Default             |
+| ------------ | ----- | ---------------------------------- | ------ | ------------------- |
 | --help       |       | Show help                          |        |                     |
 | --version    |       | Show version number                |        |                     |
 | --script     | -s    | Your npm Cypress command           | string |                     |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ npm run cy:parallel
 | --weightFile | -w    | if a weights file should be crated | bool   | false               |
 
 # Contributors
-Looking for contributors.
+  Original Author: https://github.com/tnicola
+  Total Test Time: https://github.com/stepn1k
+  Updates and cleanup: https://github.com/sezane
+  Few small tweaks: me @ https://github.com/finalcut
 # License
  MIT

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ npm run cy:parallel
 
 ### Scripts options
 
-| Option     | Alias | Description                        | Type   |
-| ---------- | ----- | ---------------------------------- | ------ |
-| --help     |       | Show help                          |        |
-| --version  |       | Show version number                |        |
-| --script   | -s    | Your npm Cypress command           | string |
-| --args     | -a    | Your npm Cypress command arguments | string |
-| --threads  | -t    | Number of threads                  | number |
-| --specsDir | -d    | Cypress specs directory.           | string |
-| --write_weights_file   | -wwf    | if a weights file should be crated; default false           | boolean |
+| Option       | Alias | Description                        | Type   | Default |
+| ------------ | ----- | ---------------------------------- | ------ | ------ |
+| --help       |       | Show help                          |        |                     |
+| --version    |       | Show version number                |        |                     |
+| --script     | -s    | Your npm Cypress command           | string |                     |
+| --args       | -a    | Your npm Cypress command arguments | string |                     |
+| --threads    | -t    | Number of threads                  | number | 3                   |
+| --specsDir   | -d    | Cypress specs directory.           | string | cypress/integration |
+| --weightFile | -w    | if a weights file should be crated | bool   | false               |
 
 # Contributors
 Looking for contributors.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yarn add cypress-parallel
 Sample:
 
 ```
--a '\"--config baseUrl=http://localhost:3000\"'
+cypress-parallel -s cy:run -t 2 -d cypress -a '\"--config baseUrl=http://localhost:3000\"'
 ```
 
 ## Launch the new script
@@ -58,9 +58,9 @@ npm run cy:parallel
 | --version    |       | Show version number                |        |                     |
 | --script     | -s    | Your npm Cypress command           | string |                     |
 | --args       | -a    | Your npm Cypress command arguments | string |                     |
-| --threads    | -t    | Number of threads                  | number | 3                   |
 | --specsDir   | -d    | Cypress specs directory.           | string | cypress/integration |
 | --weightFile | -w    | if a weights file should be crated | bool   | false               |
+| --threads    | -t    | Number of threads; must be even #  | number | 4                   |
 
 # Contributors
   Original Author: https://github.com/tnicola

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
  or
 
 ```
-yarn add cypress-parallel
+yarn add sezane/cypress-parallel
  ```
 
 ## Add a new script

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
 
 ## Install
  ```
- npm i cypress-parallel
+ npm i finalcut/cypress-parallel
  ```
 
  or
 
 ```
-yarn add cypress-parallel
+yarn add finalcut/cypress-parallel
  ```
 
 ## Add a new script

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ npm run cy:parallel
 
 ### Scripts options
 
-| Option       | Alias | Description                        | Type   | Default             |
-| ------------ | ----- | ---------------------------------- | ------ | ------------------- |
-| --help       |       | Show help                          |        |                     |
-| --version    |       | Show version number                |        |                     |
-| --script     | -s    | Your npm Cypress command           | string |                     |
-| --args       | -a    | Your npm Cypress command arguments | string |                     |
-| --specsDir   | -d    | Cypress specs directory.           | string | cypress/integration |
-| --weightFile | -w    | if a weights file should be crated | bool   | false               |
-| --threads    | -t    | Number of threads; must be even #  | number | 4                   |
+| Option            | Alias | Description                        | Type   | Default             |
+| ----------------- | ----- | ---------------------------------- | ------ | ------------------- |
+| --help            |       | Show help                          |        |                     |
+| --version         |       | Show version number                |        |                     |
+| --script          | -s    | Your npm Cypress command           | string |                     |
+| --args            | -a    | Your npm Cypress command arguments | string |                     |
+| --specsDir        | -d    | Cypress specs directory.           | string | cypress/integration |
+| --writeWeightFile | -w    | if a weights file should be crated | bool   | false               |
+| --threads         | -t    | Number of threads; must be even #  | number | 4                   |
 
 # Contributors
  *  Original Author: https://github.com/tnicola

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
 
 ## Install
  ```
- npm i cypress-parallel
+ npm i sezane/cypress-parallel
  ```
 
  or

--- a/cli.js
+++ b/cli.js
@@ -218,14 +218,6 @@ const start = () => {
       totalPending += totalPending;
       specWeights[name] = { time: test.duration, weight: 0 };
       table.push([name, `${formatTime(test.duration)}`, test.tests, test.passes, test.failures, test.pending]);
-      table.push([
-        name,
-        `${formatTime(test.duration)}`,
-        test.tests,
-        test.passes,
-        test.failures,
-        test.pending
-      ]);
     }
     table.push("Results", `${formatTime(totalDuration)}`, totalTests, totalPasses, totalTests-totalPasses, totalPending);
     console.log(table.toString());

--- a/cli.js
+++ b/cli.js
@@ -39,7 +39,7 @@ if (!CY_SCRIPT) {
   throw new Error('Expected command, e.g.: cypress-parallel <cypress-script>');
 }
 
-let N_THREADS = argv.threads ? argv.threads : 2;
+let N_THREADS = argv.threads ? argv.threads : 3;
 const DAFAULT_WEIGHT = 1;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
 const WRITE_WEIGHTS_FILE = argv.write_weights_file ? argv.write_weights_file : false;

--- a/cli.js
+++ b/cli.js
@@ -40,7 +40,7 @@ if (!CY_SCRIPT) {
   throw new Error('Expected command, e.g.: cypress-parallel <cypress-script>');
 }
 
-let N_THREADS = argv.threads ? argv.threads : 4;
+let N_THREADS = argv.threads ? argv.threads : 2;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
 const WRITE_WEIGHTS_FILE = argv.writeWeightFile ? argv.writeWeightFile : false;
 const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];

--- a/cli.js
+++ b/cli.js
@@ -226,7 +226,16 @@ const start = () => {
         test.pending
       ]);
     }
-    table.push("Results", `${formatTime(totalDuration)}`, totalTests, totalPasses, totalTests-totalPasses, totalPending);
+
+    table.push([
+      'Results',
+      `${formatTime(totalDuration)}`,
+      totalTests,
+      totalPasses,
+      totalTests-totalPasses,
+      totalPending
+    ]);
+
 
     console.log(table.toString());
 

--- a/cli.js
+++ b/cli.js
@@ -94,6 +94,7 @@ const formatTime = function(millisec) {
 };
 
 const start = () => {
+  const startRunTime = new Date().getTime()
   const fileList = getAllFiles(SPEC_FILES_PATH);
   let specWeights = {};
   try {
@@ -101,6 +102,8 @@ const start = () => {
   } catch (err) {
     console.log(`Weight file not found in path: ${WEIGHTS_JSON}`);
   }
+
+  console.log(`Preparing to run ${fileList.length} spec files.  Please wait, the first result may take a bit of time to appear.`)
 
   let map = new Map();
   for (let f of fileList) {
@@ -194,6 +197,7 @@ const start = () => {
   });
 
   let timeMap = new Map();
+  let threadTimes = []
   Promise.all(children).then(resultMaps => {
     resultMaps.forEach((m, t) => {
       let totTimeThread = 0;
@@ -201,6 +205,7 @@ const start = () => {
         totTimeThread += test.duration;
       }
       console.log(`Thread ${t} time: ${formatTime(totTimeThread)}`);
+      threadTimes.push(totTimeThread)
 
       timeMap = new Map([...timeMap, ...m]);
     });
@@ -234,17 +239,6 @@ const start = () => {
       ]);
     }
 
-    table.push([
-      'Results',
-      `${formatTime(totalDuration)}`,
-      totalTests,
-      totalPasses,
-      totalTests-totalPasses,
-      totalPending
-    ]);
-
-    console.log(table.toString());
-
     if (WRITE_WEIGHTS_FILE) {
       Object.keys(specWeights).forEach(spec => {
       specWeights[spec].weight = Math.floor(
@@ -259,6 +253,21 @@ const start = () => {
         console.log('Generated file parallel-weights.json.');
       });
     }
+
+    const endRunTime = new Date().getTime()
+    const totalRunTime = endRunTime - startRunTime
+
+
+    table.push([
+      'Total Run Time and Final Results',
+      `${formatTime(totalRunTime)}`,
+      totalTests,
+      totalPasses,
+      totalTests-totalPasses,
+      totalPending
+    ]);
+
+    console.log(table.toString());
   });
 };
 

--- a/cli.js
+++ b/cli.js
@@ -217,9 +217,17 @@ const start = () => {
       totalPasses += test.passes;
       totalPending += totalPending;
       specWeights[name] = { time: test.duration, weight: 0 };
-      table.push([name, `${formatTime(test.duration)}`, test.tests, test.passes, test.failures, test.pending]);
+      table.push([
+        name,
+        `${formatTime(test.duration)}`,
+        test.tests,
+        test.passes,
+        test.failures,
+        test.pending
+      ]);
     }
     table.push("Results", `${formatTime(totalDuration)}`, totalTests, totalPasses, totalTests-totalPasses, totalPending);
+
     console.log(table.toString());
 
     Object.keys(specWeights).forEach(spec => {

--- a/cli.js
+++ b/cli.js
@@ -75,15 +75,17 @@ const getRandomInt = function (max) {
   return Math.floor(Math.random() * Math.floor(max));
 };
 
-const formatTime = function(timeMs) {
-  const seconds = Math.ceil(timeMs / 1000);
-  const sec = seconds % 60;
-  const min = Math.floor(seconds / 60);
-  let res = '';
+const formatTime = function(duration) {
+  var milliseconds = parseInt((duration % 1000) / 100),
+    seconds = Math.floor((duration / 1000) % 60),
+    minutes = Math.floor((duration / (1000 * 60)) % 60),
+    hours = Math.floor((duration / (1000 * 60 * 60)) % 24);
 
-  if (min) res += `${min}m `;
-  res += `${sec}s`;
-  return res;
+  hours = (hours < 10) ? "0" + hours : hours;
+  minutes = (minutes < 10) ? "0" + minutes : minutes;
+  seconds = (seconds < 10) ? "0" + seconds : seconds;
+
+  return hours + "h " + minutes + "m " + seconds + "s " + milliseconds + " ms";
 };
 
 const start = () => {

--- a/cli.js
+++ b/cli.js
@@ -29,7 +29,7 @@ const argv = yargs
     type: 'string',
     description: 'Your npm Cypress command arguments'
   })
-  .option('weightFile', {
+  .option('writeWeightFile', {
       alias: 'w',
       type: 'boolean',
       description: `Write ${WEIGHTS_JSON} file ? `
@@ -42,7 +42,7 @@ if (!CY_SCRIPT) {
 
 let N_THREADS = argv.threads ? argv.threads : 4;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
-const WRITE_WEIGHTS_FILE = argv.weightFile ? argv.weightFile : false;
+const WRITE_WEIGHTS_FILE = argv.writeWeightFile ? argv.writeWeightFile : false;
 const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];
 
 const COLORS = [

--- a/cli.js
+++ b/cli.js
@@ -40,7 +40,7 @@ if (!CY_SCRIPT) {
   throw new Error('Expected command, e.g.: cypress-parallel <cypress-script>');
 }
 
-let N_THREADS = argv.threads ? argv.threads : 3;
+let N_THREADS = argv.threads ? argv.threads : 4;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
 const WRITE_WEIGHTS_FILE = argv.weightFile ? argv.weightFile : false;
 const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];

--- a/cli.js
+++ b/cli.js
@@ -203,7 +203,7 @@ const start = () => {
     let table = new Table({
       head: ['Spec', 'Time', 'Tests', 'Passing', 'Failing', 'Pending'],
       style: { head: ['green'] },
-      colWidths: [25, 8, 7, 9, 9, 9]
+      colWidths: [45, 25, 7, 9, 9, 9]
     });
 
     let totalTests = 0;

--- a/cli.js
+++ b/cli.js
@@ -41,7 +41,6 @@ if (!CY_SCRIPT) {
 }
 
 let N_THREADS = argv.threads ? argv.threads : 3;
-const DAFAULT_WEIGHT = 1;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
 const WRITE_WEIGHTS_FILE = argv.weightFile ? argv.weightFile : false;
 const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];

--- a/cli.js
+++ b/cli.js
@@ -28,8 +28,9 @@ const argv = yargs
     alias: 'a',
     type: 'string',
     description: 'Your npm Cypress command arguments'
-  }).option('write_weights_file', {
-      alias: 'wwf',
+  })
+  .option('weightFile', {
+      alias: 'w',
       type: 'boolean',
       description: `Write ${WEIGHTS_JSON} file ? `
   }).argv;
@@ -42,7 +43,7 @@ if (!CY_SCRIPT) {
 let N_THREADS = argv.threads ? argv.threads : 3;
 const DAFAULT_WEIGHT = 1;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
-const WRITE_WEIGHTS_FILE = argv.write_weights_file ? argv.write_weights_file : false;
+const WRITE_WEIGHTS_FILE = argv.weightFile ? argv.weightFile : false;
 const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];
 
 const COLORS = [

--- a/cli.js
+++ b/cli.js
@@ -204,12 +204,20 @@ const start = () => {
       colWidths: [25, 8, 7, 9, 9, 9]
     });
 
+    let totalTests = 0;
+    let totalPasses = 0;
     let totalDuration = 0;
+    let totalPending = 0;
+
     let totalWeight = timeMap.size * 10;
     let specWeights = {};
     for (let [name, test] of timeMap) {
       totalDuration += test.duration;
+      totalTests += test.tests;
+      totalPasses += test.passes;
+      totalPending += totalPending;
       specWeights[name] = { time: test.duration, weight: 0 };
+      table.push([name, `${formatTime(test.duration)}`, test.tests, test.passes, test.failures, test.pending]);
       table.push([
         name,
         `${formatTime(test.duration)}`,
@@ -219,7 +227,7 @@ const start = () => {
         test.pending
       ]);
     }
-
+    table.push("Results", `${formatTime(totalDuration)}`, totalTests, totalPasses, totalTests-totalPasses, totalPending);
     console.log(table.toString());
 
     Object.keys(specWeights).forEach(spec => {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "cli.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sezane/cypress-parallel.git"
+    "url": "git+https://github.com/finalcut/cypress-parallel.git"
   },
   "keywords": [
     "cypress",
@@ -16,9 +16,9 @@
   "author": "Nicola Tommasi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sezane/cypress-parallel/issues"
+    "url": "https://github.com/finalcut/cypress-parallel/issues"
   },
-  "homepage": "https://github.com/sezane/cypress-parallel#readme",
+  "homepage": "https://github.com/finalcut/cypress-parallel#readme",
   "bin": {
     "cypress-parallel": "./cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "cypress-parallel",
-  "version": "0.1.8",
+  "version": "0.1.15",
   "description": "Reduce up to 40% your Cypress suite execution time parallelizing the test run on the same machine.",
   "main": "cli.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/finalcut/cypress-parallel.git"
+    "url": "git+https://github.com/sezane/cypress-parallel.git"
   },
   "keywords": [
     "cypress",
@@ -16,9 +16,9 @@
   "author": "Nicola Tommasi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/finalcut/cypress-parallel/issues"
+    "url": "https://github.com/sezane/cypress-parallel/issues"
   },
-  "homepage": "https://github.com/finalcut/cypress-parallel#readme",
+  "homepage": "https://github.com/sezane/cypress-parallel#readme",
   "bin": {
     "cypress-parallel": "./cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-parallel",
-  "version": "0.1.8",
+  "version": "0.1.16",
   "description": "Reduce up to 40% your Cypress suite execution time parallelizing the test run on the same machine.",
   "main": "cli.js",
   "repository": {


### PR DESCRIPTION
I made some changes to your fork so figured I'd offer them back to you.  

I renamed your new argument of `write_weights_file` to `writeWeightFile` to match the orginal authors style for aguments.

Some other changes:

* fixed time formatting
* improved time computation for each thread
* defaulted threads to 4 instead of 2
* updated readme documentation
* fixed width of results table to be more readable
* added new change to show total time across all threads (stolen and modified PR waiting on OP repo)


Hope you can find some use in them.